### PR TITLE
Implement actions for mac-m1 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test the GitHub action of this repository
 on: [push]
 
 jobs:
-  test-build-and-cache:
+  test-build-and-cache-by-root:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -20,17 +20,14 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
-    - name: Run this repo's action
-      # For an external repo wishing to use this action, the uses field needs to be:
-      # uses: kadena-io/setup-nix-with-cache@{The version you want to use}
-      uses: ./
+    - # For an external repo wishing to use this action, the uses field needs to be:
+      # uses: kadena-io/setup-nix-with-cache/by-root@{The version you want to use}
+      uses: ./by-root
       with:
         cache_url: s3://nodemon-nix-cache?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
 
-    # This step is probably not needed for external repos that use this action
-    - name: Set up Nix path
-      run: echo "NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/22.11.tar.gz" >> $GITHUB_ENV
+    - uses: ./copy-root-aws-credentials
 
     - name: Attempt to build a new derivation with Nix
       run: |
@@ -40,3 +37,34 @@ jobs:
       run: |
         nix-build -E '(import <nixpkgs> {}).runCommand "fetch-example" {} "echo Example > $out"'
 
+  test-build-and-cache-by-runner:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, mac-m1]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - uses: ./by-runner
+      with:
+        cache_url: s3://nodemon-nix-cache?region=us-east-1
+        signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+
+    - uses: ./copy-root-aws-credentials
+
+    - name: Attempt to build a new derivation with Nix
+      run: |
+        nix-build -E '(import <nixpkgs> {}).writeText "build-example" (builtins.toString builtins.currentTime)'
+
+    - name: Attempt to fetch an existing cache entry
+      run: |
+        nix-build -E '(import <nixpkgs> {}).runCommand "fetch-example" {} "echo Example > $out"'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*NOTE*: The actions in this repository are meant to be used with Kadena's own github actions infrastructure, therefore they contain Kadena-specific logic. They may still be useful for external users out of the box or after some tweaks, but that's not officially supported by Kadena.
+
 # Set up Nix along with caching
 
 A set of GitHub actions for setting up a multi-user Nix environment with a binary cache for uploading and fetching derivation outputs.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
-# Set up Nix along with a custom cache
+# Set up Nix along with caching
 
-GitHub action for setting up a simple Nix environment that caches to a custom Nix cache
+A set of GitHub actions for setting up a multi-user Nix environment with a binary cache for uploading and fetching derivation outputs.
 
-## Usage
+The repository contains the following actions:
+* `by-root`: Sets up `nix.conf` with a `post-build-hook` so that intermediate and final build outputs are uploaded by the root.
+* `by-runner`: Starts a background upload job as the action runner and sets up `nix.conf` with a `post-build-hook` so that intermediate and final build outputs are passed to the action runner for cache uploads.
+* `copy-root-aws-credentials`: Copies the AWS credentials of the action runner to the root user. This is meant to be used for giving the root user access to binary caches. In the case of a `by-root` workflow, this can be used to give root write permissions and in the case of a private cache, it can be used to give root read permissions.
+
+Depending on the binary cache in question, these actions can be used together in a number of ways, some example use cases:
+* A public AWS S3 bucket: A `by-root` + `copy-root-aws-credentials` setup is recommended. One can also use `by-runner` only, but `by-runner` adds around a minute of setup time to each run.
+* A private AWS S3 bucket: `by-root` + `copy-root-aws-credentials` will work same as before. If `by-runner` is preferred, it will also `copy-root-aws-credentials` since otherwise the Nix builder won't be able to read from the private S3 bucket.
+* Other kind of cache (e.g. over SSH, etc.): As long as the github action runner has access to the cache, `by-runner` can be used to enable cache uploads, but if the cache is private, a custom step will be required to give the root user access to it. If root is given access, then `by-root` can also be used instead of `by-runner` in order to avoid the setup overhead.
+
+## Example
 
 Please check [.github/workflows/test.yml](.github/workflows/test.yml) for an example using an AWS S3 bucket as a Nix cache.

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
-        nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" &
+        (nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" &) &
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
         set -f # disable globbing
         export IFS=' '
         echo "Uploading paths" \$OUT_PATHS
-        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 

--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,10 @@ runs:
         experimental-features = nix-command fetch-closure flakes
         EOF
 
-
-
-
-
-
+    - name: Restart the Nix daemon on MacOS
+      shell: bash
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        sudo launchctl stop org.nixos.nix-daemon;
+        sudo launchctl start org.nixos.nix-daemon;
 

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,12 @@ runs:
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
-        ( nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" & ) &
+        ( nix-shell -p socat --command "socat -ddd TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" & ) &
+
+        echo waiting for socat to start
+        sleep 1
+
+        netstat -tuln | grep 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         read -r OUT_PATHS
         export IFS=' '
         echo Uploading paths \$OUT_PATHS 1>&2
-        echo nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
@@ -42,7 +42,7 @@ runs:
 
         sleep 3
 
-        echo "Some_Path" | nc localhost 54321
+        echo $(nix-build '<nixpkgs>' -A nmap) | nc localhost 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ runs:
         experimental-features = nix-command fetch-closure flakes
         EOF
 
+        echo Copy aws credentials to /var/root/.aws
+        sudo mkdir -p /var/root/.aws
+        sudo cp -r ~/.aws/* /var/root/.aws
+
     - name: Restart the Nix daemon on MacOS
       shell: bash
       if: ${{ runner.os == 'macOS' }}

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
         read -r OUT_PATHS
         export IFS=' '
         echo Uploading paths \$OUT_PATHS 1>&2
-        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        echo nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
@@ -39,9 +39,7 @@ runs:
 
         $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
 
-        echo Check that the port is open
-        sleep 5
-        netstat -tuln | grep 54321
+        echo "Some_Path" | nc localhost 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash

--- a/action.yml
+++ b/action.yml
@@ -35,11 +35,11 @@ runs:
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
-        ( nix-shell -p socat --command "socat -ddd TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" & ) &
+        NCAT=$(nix-build '<nixpkgs>' -A nmap)/bin/ncat
 
-        echo waiting for socat to start
-        sleep 20
+        $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
 
+        echo Check that the port is open
         netstat -tuln | grep 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,7 @@ runs:
           echo Uploading paths \$OUT_PATHS 1>&2
           nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
         EOF
+        chmod a+x $TMP_DIR/upload-paths.sh
 
         nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" &
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,8 @@ runs:
 
         $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
 
+        sleep 3
+
         echo "Some_Path" | nc localhost 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ runs:
         $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
 
         echo Check that the port is open
+        sleep 5
         netstat -tuln | grep 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF

--- a/action.yml
+++ b/action.yml
@@ -28,14 +28,14 @@ runs:
         echo "${{ inputs.signing_private_key }}" > "$TMP_DIR/key.private"
 
         tee $TMP_DIR/upload-paths.sh <<EOF
-          read -r OUT_PATHS
-          export IFS=' '
-          echo Uploading paths \$OUT_PATHS 1>&2
-          nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        read -r OUT_PATHS
+        export IFS=' '
+        echo Uploading paths \$OUT_PATHS 1>&2
+        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
-        (nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" &) &
+        ( nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" & ) &
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash

--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,14 @@ runs:
         TMP_DIR=$(mktemp -d)
         echo "${{ inputs.signing_private_key }}" > "$TMP_DIR/key.private"
 
+        env > $TMP_DIR/env-vars.txt
+
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash
+
+        # Restore the environment variables
+        source $TMP_DIR/env-vars.txt
+
 
         set -euo pipefail
         set -f # disable globbing

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
         #!/usr/bin/env bash
         read -r OUT_PATHS
         export IFS=' '
-        echo Uploading paths \$OUT_PATHS 1>&2
-        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        echo Uploading paths \$OUT_PATHS
+        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
         set -f # disable globbing
         echo "Built paths:" \$OUT_PATHS
         # echo \$OUT_PATHS | nc localhost 54321
-        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
+        $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 

--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,11 @@ runs:
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
-        NCAT=$(nix-build '<nixpkgs>' -A nmap)/bin/ncat
+        # NCAT=$(nix-build '<nixpkgs>' -A nmap)/bin/ncat
+        # $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
 
-        $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
-
-        sleep 3
-
-        echo $(nix-build '<nixpkgs>' -A nmap) | nc localhost 54321
+        # sleep 3
+        # echo $(nix-build '<nixpkgs>' -A nmap) | nc localhost 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash
@@ -50,7 +48,8 @@ runs:
         set -euo pipefail
         set -f # disable globbing
         echo "Built paths:" \$OUT_PATHS
-        echo \$OUT_PATHS | nc localhost 54321
+        # echo \$OUT_PATHS | nc localhost 54321
+        nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
         echo "${{ inputs.signing_private_key }}" > "$TMP_DIR/key.private"
 
         tee $TMP_DIR/upload-paths.sh <<EOF
+        #!/usr/bin/env bash
         read -r OUT_PATHS
         export IFS=' '
         echo Uploading paths \$OUT_PATHS 1>&2

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
         ( nix-shell -p socat --command "socat -ddd TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" & ) &
 
         echo waiting for socat to start
-        sleep 1
+        sleep 20
 
         netstat -tuln | grep 54321
 

--- a/action.yml
+++ b/action.yml
@@ -67,8 +67,8 @@ runs:
         sudo mkdir -p /var/root/.aws
         sudo cat <<EOF > /var/root/.aws/credentials
         [default]
-        aws_access_key_id = ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws_secret_access_key = ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws_access_key_id = $AWS_ACCESS_KEY_ID
+        aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
         EOF
 
     - name: Restart the Nix daemon on MacOS

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
 
         echo Copy aws credentials to /var/root/.aws
         sudo mkdir -p /var/root/.aws
-        sudo cat <<EOF > /var/root/.aws/credentials
+        sudo sh -c 'cat - > /var/root/.aws/credentials' <<EOF
         [default]
         aws_access_key_id = $AWS_ACCESS_KEY_ID
         aws_secret_access_key = $AWS_SECRET_ACCESS_KEY

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         TMP_DIR=$(mktemp -d)
         echo "${{ inputs.signing_private_key }}" > "$TMP_DIR/key.private"
 
-        $TMP_DIR/upload-paths.sh <<EOF
+        tee $TMP_DIR/upload-paths.sh <<EOF
           read -r OUT_PATHS
           export IFS=' '
           echo Uploading paths \$OUT_PATHS 1>&2

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,11 @@ runs:
 
         echo Copy aws credentials to /var/root/.aws
         sudo mkdir -p /var/root/.aws
-        sudo cp -r ~/.aws/* /var/root/.aws
+        sudo cat <<EOF > /var/root/.aws/credentials
+        [default]
+        aws_access_key_id = ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key = ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        EOF
 
     - name: Restart the Nix daemon on MacOS
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -27,20 +27,22 @@ runs:
         TMP_DIR=$(mktemp -d)
         echo "${{ inputs.signing_private_key }}" > "$TMP_DIR/key.private"
 
-        env > $TMP_DIR/env-vars.txt
+        $TMP_DIR/upload-paths.sh <<EOF
+          read -r OUT_PATHS
+          export IFS=' '
+          echo Uploading paths \$OUT_PATHS 1>&2
+          nix copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        EOF
+
+        nix-shell -p socat --command "socat TCP4-LISTEN:54321,fork EXEC:$TMP_DIR/upload-paths.sh" &
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash
 
-        # Restore the environment variables
-        source $TMP_DIR/env-vars.txt
-
-
         set -euo pipefail
         set -f # disable globbing
-        export IFS=' '
-        echo "Uploading paths" \$OUT_PATHS
-        $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS
+        echo "Built paths:" \$OUT_PATHS
+        echo \$OUT_PATHS | nc localhost 54321
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Set NIX_PATH
       if: ${{ runner.name == 'mac-m1' }}
       run: |
-        echo "export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
+        echo "NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
       shell: bash
 
     - run: |

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -58,6 +58,7 @@ runs:
         substituters = ${{ inputs.cache_url }} https://cache.nixos.org/
         trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
         secret-key-files = $TMP_DIR/key.private
+        post-build-hook = $TMP_DIR/post-build-hook.sh
         experimental-features = nix-command fetch-closure flakes
         EOF
 

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -68,11 +68,12 @@ runs:
       run: |
         sudo launchctl stop org.nixos.nix-daemon
         sudo launchctl start org.nixos.nix-daemon
-        sleep 50
+        while ! nix store ping 2>/dev/null; do
+            sleep 1
+        done
 
     - name: Restart the Nix daemon on Linux
       shell: bash
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo systemctl restart nix-daemon.service
-        sleep 1

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -41,7 +41,6 @@ runs:
         set -euo pipefail
         set -f # disable globbing
         echo "Built paths:" \$OUT_PATHS
-        # echo \$OUT_PATHS | nc localhost 54321
         $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -46,8 +46,14 @@ runs:
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 
+        CERTFILEOPT=$( [[ "$OSTYPE" =~ darwin ]] && echo "ssl-cert-file = /etc/ssl/cert.pem" || echo "" )
+
         sudo mkdir -p /etc/nix/
         sudo tee /etc/nix/nix.conf <<EOF
+        show-trace = true
+        max-jobs = auto
+        $CERTFILEOPT
+        trusted-users = root ${USER:-}
         substituters = ${{ inputs.cache_url }} https://cache.nixos.org/
         trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
         secret-key-files = $TMP_DIR/key.private

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -56,7 +56,6 @@ runs:
         substituters = ${{ inputs.cache_url }} https://cache.nixos.org/
         trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
         secret-key-files = $TMP_DIR/key.private
-        post-build-hook = $TMP_DIR/post-build-hook.sh
         experimental-features = nix-command fetch-closure flakes
         EOF
 

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -68,7 +68,7 @@ runs:
       run: |
         sudo launchctl stop org.nixos.nix-daemon
         sudo launchctl start org.nixos.nix-daemon
-        sleep 1
+        sleep 50
 
     - name: Restart the Nix daemon on Linux
       shell: bash

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -1,0 +1,67 @@
+name: 'Set up Nix environment with cache uploads by the root'
+description: -|
+  This action installs Nix in multi-user mode and configures it to
+  use a custom cache. It also uploads all the build results to the cache,
+  including intermediate packages built as part of a build activity.
+  The cache uploads are performed by the root user in the post-build-hook,
+  this means that the root user needs to have the proper credentials
+  configured to have write access to the cache.
+inputs:
+  cache_url:
+    description: 'URL for the Nix cache'
+    required: true
+  signing_private_key:
+    description: The private (secret) key used for signing Nix store paths
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      if: ${{ ! runner.name == 'mac-m1' }}
+      uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - run: |
+        echo $PATH
+        nix-build --version
+      shell: bash
+
+    - name: Populate the nix.conf with cache fields
+      shell: bash
+      run: |
+        TMP_DIR=$(mktemp -d)
+        echo "${{ inputs.signing_private_key }}" > "$TMP_DIR/key.private"
+
+        tee $TMP_DIR/post-build-hook.sh <<EOF
+        #!/usr/bin/env bash
+
+        set -euo pipefail
+        set -f # disable globbing
+        echo "Built paths:" \$OUT_PATHS
+        # echo \$OUT_PATHS | nc localhost 54321
+        $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
+        EOF
+        chmod a+x $TMP_DIR/post-build-hook.sh
+
+        sudo mkdir -p /etc/nix/
+        sudo tee /etc/nix/nix.conf <<EOF
+        substituters = ${{ inputs.cache_url }} https://cache.nixos.org/
+        trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+        secret-key-files = $TMP_DIR/key.private
+        post-build-hook = $TMP_DIR/post-build-hook.sh
+        experimental-features = nix-command fetch-closure flakes
+        EOF
+
+    - name: Restart the Nix daemon on MacOS
+      shell: bash
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        sudo launchctl stop org.nixos.nix-daemon;
+        sudo launchctl start org.nixos.nix-daemon;
+
+    - name: Restart the Nix daemon on Linux
+      shell: bash
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo systemctl restart nix-daemon.service

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -45,6 +45,8 @@ runs:
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 
+        nix-build '<nixpkgs>' -A hello --no-out-link
+
         CERTFILEOPT=$( [[ "$OSTYPE" =~ darwin ]] && echo "ssl-cert-file = /etc/ssl/cert.pem" || echo "" )
 
         sudo mkdir -p /etc/nix/

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -66,11 +66,13 @@ runs:
       shell: bash
       if: ${{ runner.os == 'macOS' }}
       run: |
-        sudo launchctl stop org.nixos.nix-daemon;
-        sudo launchctl start org.nixos.nix-daemon;
+        sudo launchctl stop org.nixos.nix-daemon
+        sudo launchctl start org.nixos.nix-daemon
+        sleep 1
 
     - name: Restart the Nix daemon on Linux
       shell: bash
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo systemctl restart nix-daemon.service
+        sleep 1

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -18,6 +18,8 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz
 
     - name: Set NIX_PATH
       run: |
@@ -44,8 +46,6 @@ runs:
         $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
-
-        nix-build '<nixpkgs>' -A hello --no-out-link
 
         CERTFILEOPT=$( [[ "$OSTYPE" =~ darwin ]] && echo "ssl-cert-file = /etc/ssl/cert.pem" || echo "" )
 

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -20,7 +20,13 @@ runs:
       if: ${{ runner.name != 'mac-m1' }}
       uses: cachix/install-nix-action@v22
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz
+
+    - name: Set NIX_PATH
+      if: ${{ runner.name == 'mac-m1' }}
+      run: |
+        echo "export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
+      shell: bash
 
     - run: |
         echo $PATH

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      if: ${{ ! runner.name == 'mac-m1' }}
+      if: ${{ runner.name != 'mac-m1' }}
       uses: cachix/install-nix-action@v22
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/by-root/action.yml
+++ b/by-root/action.yml
@@ -17,13 +17,9 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      if: ${{ runner.name != 'mac-m1' }}
       uses: cachix/install-nix-action@v22
-      with:
-        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz
 
     - name: Set NIX_PATH
-      if: ${{ runner.name == 'mac-m1' }}
       run: |
         echo "NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
       shell: bash

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -81,11 +81,13 @@ runs:
       shell: bash
       if: ${{ runner.os == 'macOS' }}
       run: |
-        sudo launchctl stop org.nixos.nix-daemon;
-        sudo launchctl start org.nixos.nix-daemon;
+        sudo launchctl stop org.nixos.nix-daemon
+        sudo launchctl start org.nixos.nix-daemon
+        sleep 1
 
     - name: Restart the Nix daemon on Linux
       shell: bash
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo systemctl restart nix-daemon.service
+        sleep 1

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -83,11 +83,12 @@ runs:
       run: |
         sudo launchctl stop org.nixos.nix-daemon
         sudo launchctl start org.nixos.nix-daemon
-        sleep 1
+        while ! nix store ping 2>/dev/null; do
+            sleep 1
+        done
 
     - name: Restart the Nix daemon on Linux
       shell: bash
       if: ${{ runner.os == 'Linux' }}
       run: |
         sudo systemctl restart nix-daemon.service
-        sleep 1

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Set NIX_PATH
       if: ${{ runner.name == 'mac-m1' }}
       run: |
-        echo "export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
+        echo "NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
       shell: bash
 
     - run: |

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -18,6 +18,8 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz
 
     - name: Set NIX_PATH
       run: |

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -60,8 +60,14 @@ runs:
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 
+        CERTFILEOPT=$( [[ "$OSTYPE" =~ darwin ]] && echo "ssl-cert-file = /etc/ssl/cert.pem" || echo "" )
+
         sudo mkdir -p /etc/nix/
         sudo tee /etc/nix/nix.conf <<EOF
+        show-trace = true
+        max-jobs = auto
+        $CERTFILEOPT
+        trusted-users = root ${USER:-}
         substituters = ${{ inputs.cache_url }} https://cache.nixos.org/
         trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
         secret-key-files = $TMP_DIR/key.private

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -1,7 +1,11 @@
-name: 'Set up Nix environment with caching'
+name: 'Set up Nix environment with cache uploads by the runner'
 description: -|
-  This action installs Nix in single-user mode and configures it to
-  use a custom cache
+  This action installs Nix in multi-user mode and configures it to
+  use a custom cache. It also uploads all the build results to the cache,
+  including intermediate packages built as part of a build activity.
+  The cache uploads are performed by the runner user in the post-build-hook,
+  this means that the runner user needs to have the proper credentials
+  configured to have write access to the cache.
 inputs:
   cache_url:
     description: 'URL for the Nix cache'
@@ -13,8 +17,10 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      if: ${{ ! contains(runner.arch,'ARM') }}
-      uses: nixbuild/nix-quick-install-action@v22
+      if: ${{ ! runner.name == 'mac-m1' }}
+      uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
 
     - run: |
         echo $PATH
@@ -36,11 +42,11 @@ runs:
         EOF
         chmod a+x $TMP_DIR/upload-paths.sh
 
-        # NCAT=$(nix-build '<nixpkgs>' -A nmap)/bin/ncat
-        # $NCAT -k -l 54321 -e $TMP_DIR/upload-paths.sh &
+        NMAP=$(nix-build '<nixpkgs>' -A nmap --no-out-link)
+        $NMAP/bin/ncat -k -l 54321 -e $TMP_DIR/upload-paths.sh &
 
-        # sleep 3
-        # echo $(nix-build '<nixpkgs>' -A nmap) | nc localhost 54321
+        sleep 1
+        echo $NMAP | nc localhost 54321
 
         tee $TMP_DIR/post-build-hook.sh <<EOF
         #!/usr/bin/env bash
@@ -48,8 +54,7 @@ runs:
         set -euo pipefail
         set -f # disable globbing
         echo "Built paths:" \$OUT_PATHS
-        # echo \$OUT_PATHS | nc localhost 54321
-        $(which nix) copy --to "${{ inputs.cache_url }}" \$OUT_PATHS 2>&1
+        echo \$OUT_PATHS | nc localhost 54321
         EOF
         chmod a+x $TMP_DIR/post-build-hook.sh
 
@@ -62,14 +67,6 @@ runs:
         experimental-features = nix-command fetch-closure flakes
         EOF
 
-        echo Copy aws credentials to /var/root/.aws
-        sudo mkdir -p /var/root/.aws
-        sudo sh -c 'cat - > /var/root/.aws/credentials' <<EOF
-        [default]
-        aws_access_key_id = $AWS_ACCESS_KEY_ID
-        aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
-        EOF
-
     - name: Restart the Nix daemon on MacOS
       shell: bash
       if: ${{ runner.os == 'macOS' }}
@@ -77,3 +74,8 @@ runs:
         sudo launchctl stop org.nixos.nix-daemon;
         sudo launchctl start org.nixos.nix-daemon;
 
+    - name: Restart the Nix daemon on Linux
+      shell: bash
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo systemctl restart nix-daemon.service

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -20,7 +20,13 @@ runs:
       if: ${{ runner.name != 'mac-m1' }}
       uses: cachix/install-nix-action@v22
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz
+
+    - name: Set NIX_PATH
+      if: ${{ runner.name == 'mac-m1' }}
+      run: |
+        echo "export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
+      shell: bash
 
     - run: |
         echo $PATH

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      if: ${{ ! runner.name == 'mac-m1' }}
+      if: ${{ runner.name != 'mac-m1' }}
       uses: cachix/install-nix-action@v22
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/by-runner/action.yml
+++ b/by-runner/action.yml
@@ -17,13 +17,9 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      if: ${{ runner.name != 'mac-m1' }}
       uses: cachix/install-nix-action@v22
-      with:
-        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz
 
     - name: Set NIX_PATH
-      if: ${{ runner.name == 'mac-m1' }}
       run: |
         echo "NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz" >> $GITHUB_ENV
       shell: bash

--- a/copy-root-aws-credentials/action.yml
+++ b/copy-root-aws-credentials/action.yml
@@ -25,7 +25,7 @@ runs:
         main: |
           echo Copy aws credentials to $AWS_ROOT_PATH
           sudo mkdir -p $AWS_ROOT_PATH
-          sudo sh -c 'cat - > $AWS_ROOT_PATH/credentials' <<EOF
+          sudo sh -c "cat - > $AWS_ROOT_PATH/credentials" <<EOF
           [default]
           aws_access_key_id = $AWS_ACCESS_KEY_ID
           aws_secret_access_key = $AWS_SECRET_ACCESS_KEY

--- a/copy-root-aws-credentials/action.yml
+++ b/copy-root-aws-credentials/action.yml
@@ -7,11 +7,20 @@ description: -|
 runs:
   using: composite
   steps:
+    - name: Determine AWS root path
+      id: aws-root-path
+      shell: bash
+      run: |
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          echo "::set-output name=path::/var/root/.aws"
+        else
+          echo "::set-output name=path::/root/.aws"
+        fi
+
     - name: Copy aws credentials to root and clean up at the end
       uses: pyTooling/Actions/with-post-step@v0.4.5
       env:
-        AWS_ROOT_PATH: |
-          ${{ runner.os == 'macOS' ? '/var/root/.aws' : '/root/.aws' }}
+        AWS_ROOT_PATH: ${{ steps.aws-root-path.outputs.path }}
       with:
         main: |
           echo Copy aws credentials to $AWS_ROOT_PATH

--- a/copy-root-aws-credentials/action.yml
+++ b/copy-root-aws-credentials/action.yml
@@ -12,9 +12,9 @@ runs:
       shell: bash
       run: |
         if [[ "${{ runner.os }}" == "macOS" ]]; then
-          echo "::set-output name=path::/var/root/.aws"
+          echo "path=/var/root/.aws" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=path::/root/.aws"
+          echo "path=/root/.aws" >> $GITHUB_OUTPUT
         fi
 
     - name: Copy aws credentials to root and clean up at the end

--- a/copy-root-aws-credentials/action.yml
+++ b/copy-root-aws-credentials/action.yml
@@ -1,0 +1,25 @@
+name: 'Copy the AWS credentials to the root user'
+description: -|
+  This action copies the AWS credentials from the runner user to
+  the root user. This is meant to be used for actions where the
+  Nix daemon needs to read from or write to a binary cache that
+  requires authentication.
+runs:
+  using: composite
+  steps:
+    - name: Copy aws credentials to root and clean up at the end
+      uses: pyTooling/Actions/with-post-step@v0.4.5
+      env:
+        AWS_ROOT_PATH: |
+          ${{ runner.os == 'macOS' ? '/var/root/.aws' : '/root/.aws' }}
+      with:
+        main: |
+          echo Copy aws credentials to $AWS_ROOT_PATH
+          sudo mkdir -p $AWS_ROOT_PATH
+          sudo sh -c 'cat - > $AWS_ROOT_PATH/credentials' <<EOF
+          [default]
+          aws_access_key_id = $AWS_ACCESS_KEY_ID
+          aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+          EOF
+        post: |
+          sudo rm -rf $AWS_ROOT_PATH


### PR DESCRIPTION
This PR splits the `setup-nix-with-cache` action into 3 separate actions living under the `by-root`, `by-runner` and `copy-root-aws-credentials` folders. See [the relevant README  section](https://github.com/kadena-io/setup-nix-with-cache/tree/a342a416167db15673ea3fb76de9105f158368ea#set-up-nix-along-with-caching) about how they're meant to be used together.

The major change here is that we're moving from [nixbuild/nix-quick-install-action](https://github.com/nixbuild/nix-quick-install-action) to [cachix/install-nix-action](https://github.com/cachix/install-nix-action). `nixbuild/nix-quick-install-action` installs Nix in single-user mode, while the new `cachix/install-nix-action` installs it in multi-user mode. The setup was simpler in single-user mode and it was faster to install, but we had to move away from it because single-user installation of Nix isn't really supported on MacOS and it has rough edges. 

That said, the major benefit we're getting from the new multi-user install is Nix's secure sandboxing during builds. In multi-user mode, all derivations are built by unprivileged build users inside isolated environments, meaning that any potentially malicious package wouldn't have access to the action runner's privileges.

The PR also adds some ad-hoc logic for the `mac-m1` runners hosted by us for the repositories of the kadena-io organization enabling these actions to run on those runners.